### PR TITLE
Allow videos in portrait

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,7 +68,6 @@
         <activity
             android:name=".features.videoplayer.VideoPlayerActivity"
             android:configChanges="orientation|keyboardHidden|screenLayout|screenSize"
-            android:screenOrientation="landscape"
             android:theme="@style/AppTheme.NoActionBar.Dark"/>
         <activity
             android:name=".features.tour.TourLoginActivity"

--- a/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/data/local/AppLocalRepository.java
+++ b/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/data/local/AppLocalRepository.java
@@ -73,4 +73,9 @@ public class AppLocalRepository implements LocalRepository {
         return defaultSharedPreferences.getString(SettingsFragment.KEY_STARTUP_FRAGMENT,
                 SettingsFragment.STARTUP_FRAGMENT_GAMES);
     }
+
+    @Override
+    public boolean getOpenYouTubeInApp() {
+        return defaultSharedPreferences.getBoolean(SettingsFragment.KEY_YOUTUBE_IN_APP, true);
+    }
 }

--- a/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/data/local/LocalRepository.java
+++ b/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/data/local/LocalRepository.java
@@ -17,4 +17,6 @@ public interface LocalRepository {
     String getUsername();
 
     String getStartupFragment();
+
+    boolean getOpenYouTubeInApp();
 }

--- a/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/features/highlights/HighlightsFragment.java
+++ b/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/features/highlights/HighlightsFragment.java
@@ -2,6 +2,7 @@ package com.gmail.jorgegilcavazos.ballislife.features.highlights;
 
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
@@ -243,11 +244,17 @@ public class HighlightsFragment extends Fragment implements HighlightsView,
 
     @Override
     public void openYoutubeVideo(String videoId) {
-        FirebaseCrash.logcat(Log.INFO, "HighlightsFragment", "Opening youtube video: " + videoId);
-        Intent intent = YouTubeStandalonePlayer.createVideoIntent(getActivity(),
-                "AIzaSyA3jvG_4EIhAH_l3criaJx7-E_XWixOe78", /* API KEY */
-                videoId, 0, /* Start millisecond */
-                true /* Autoplay */, true /* Lightbox */);
+        Intent intent;
+        if (localRepository.getOpenYouTubeInApp()) {
+            FirebaseCrash.logcat(Log.INFO, "HighlightsFragment", "Opening youtube video in app: " + videoId);
+            intent = YouTubeStandalonePlayer.createVideoIntent(getActivity(),
+                    "AIzaSyA3jvG_4EIhAH_l3criaJx7-E_XWixOe78", /* API KEY */
+                    videoId, 0, /* Start millisecond */
+                    true /* Autoplay */, true /* Lightbox */);
+        } else {
+            FirebaseCrash.logcat(Log.INFO, "HighlightsFragment", "Opening youtube video in YouTube: " + videoId);
+            intent = new Intent(Intent.ACTION_VIEW, Uri.parse("vnd.youtube:" + videoId));
+        }
         startActivity(intent);
     }
 

--- a/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/features/highlights/HighlightsFragment.java
+++ b/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/features/highlights/HighlightsFragment.java
@@ -247,7 +247,7 @@ public class HighlightsFragment extends Fragment implements HighlightsView,
         Intent intent = YouTubeStandalonePlayer.createVideoIntent(getActivity(),
                 "AIzaSyA3jvG_4EIhAH_l3criaJx7-E_XWixOe78", /* API KEY */
                 videoId, 0, /* Start millisecond */
-                true /* Autoplay */, false /* Lightbox */);
+                true /* Autoplay */, true /* Lightbox */);
         startActivity(intent);
     }
 

--- a/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/features/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/features/settings/SettingsFragment.java
@@ -30,6 +30,7 @@ public class SettingsFragment extends PreferenceFragment
     public static final String KEY_PREF_START_TOPICS = "pref_start_topics";
     public static final String KEY_ENABLE_ALERTS = "pref_enable_alerts";
     public static final String KEY_STARTUP_FRAGMENT = "key_startup_fragment";
+    public static final String KEY_YOUTUBE_IN_APP = "in_app_youtube";
     public static final String STARTUP_FRAGMENT_GAMES = "0";
     public static final String STARTUP_FRAGMENT_RNBA = "1";
     public static final String STARTUP_FRAGMENT_HIGHLIGHTS = "2";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,9 @@
     <string name="pref_enable_alerts">Enable Alerts</string>
     <string name="key_enable_alerts">pref_enable_alerts</string>
 
+    <string name="key_enable_youtube_in_app">in_app_youtube</string>
+    <string name="pref_enable_youtube_in_app">In-app player for YouTube</string>
+
     <string name="title_settings_cga">Close Game</string>
     <string name="dialog_settings_cga">Pick teams to follow</string>
     <string name="summary_settings_cga">Receive an alert for close games</string>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -19,6 +19,11 @@
             android:key="key_startup_fragment"
             android:title="@string/pref_startup_fragment_title"/>
 
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/key_enable_youtube_in_app"
+            android:title="@string/pref_enable_youtube_in_app"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
This closes #173 

I changed the manifest to remove the "landscape" limitation.

Then noticed a [bug](https://github.com/afollestad/easy-video-player/issues/25) with the video player and implemented a workaround for it (which I copied from a comment in that issue).  This issue looked rather old so I figured a workaround was sufficient.