### PR TITLE
Issue #188: Add team totals to box score 

### DIFF
--- a/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/features/boxscore/BoxScoreFragment.java
+++ b/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/features/boxscore/BoxScoreFragment.java
@@ -175,7 +175,7 @@ public class BoxScoreFragment extends Fragment implements BoxScoreView {
         addRowToPlayersTable2("PLAYER");
         for (String player : players) {
             addRowToPlayersTable2(player);
-            if (i == 5) {
+            if (i == 5 || i == players.size()-1) {
                 addSeparatorRowToPlayers();
             }
             i++;
@@ -187,7 +187,7 @@ public class BoxScoreFragment extends Fragment implements BoxScoreView {
         for (StatLine statLine : values.getVls().getPstsg()) {
             addRowToStatsTable2(Optional.of(statLine));
             addToTeamTotalStats(statLine, total);
-            if (i == 5) {
+            if (i == 5 || i == players.size()-1) {
                 addSeparatorRowToStats(19);
             }
             i++;
@@ -217,7 +217,7 @@ public class BoxScoreFragment extends Fragment implements BoxScoreView {
         int i = 1;
         for (String player : players) {
             addRowToPlayersTable2(player);
-            if (i == 5) {
+            if (i == 5 || i == players.size()-1) {
                 addSeparatorRowToPlayers();
             }
             i++;
@@ -229,7 +229,7 @@ public class BoxScoreFragment extends Fragment implements BoxScoreView {
         for (StatLine statLine : values.getHls().getPstsg()) {
             addRowToStatsTable2(Optional.of(statLine));
             addToTeamTotalStats(statLine, total);
-            if (i == 5) {
+            if (i == 5 || i == players.size()-1) {
                 addSeparatorRowToStats(19);
             }
             i++;
@@ -315,7 +315,6 @@ public class BoxScoreFragment extends Fragment implements BoxScoreView {
         row.addView(addNormalItem(row, String.valueOf(statLine.getPm())));
 
         statsTable.addView(row, new TableLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT));
-
     }
 
     public void addToTeamTotalStats(StatLine curr, StatLine total){
@@ -343,7 +342,7 @@ public class BoxScoreFragment extends Fragment implements BoxScoreView {
 
         if (statLineOptional.isPresent()) {
             StatLine statLine = statLineOptional.get();
-//
+
             row.addView(addNormalItem(row, String.valueOf(statLine.getMin())));
             row.addView(addNormalItem(row, String.valueOf(statLine.getPts())));
             row.addView(addNormalItem(row, String.valueOf(statLine.getReb())));

--- a/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/features/boxscore/BoxScoreFragment.java
+++ b/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/features/boxscore/BoxScoreFragment.java
@@ -186,13 +186,13 @@ public class BoxScoreFragment extends Fragment implements BoxScoreView {
         addRowToStatsTable2(Optional.absent());
         for (StatLine statLine : values.getVls().getPstsg()) {
             addRowToStatsTable2(Optional.of(statLine));
-            addToTotal(statLine, total);
+            addToTeamTotalStats(statLine, total);
             if (i == 5) {
                 addSeparatorRowToStats(19);
             }
             i++;
         }
-        displayTotal(total);
+        displayTeamTotalStats(total);
         scrollView.setVisibility(View.VISIBLE);
     }
 
@@ -228,13 +228,13 @@ public class BoxScoreFragment extends Fragment implements BoxScoreView {
         addRowToStatsTable2(Optional.absent());
         for (StatLine statLine : values.getHls().getPstsg()) {
             addRowToStatsTable2(Optional.of(statLine));
-            addToTotal(statLine, total);
+            addToTeamTotalStats(statLine, total);
             if (i == 5) {
                 addSeparatorRowToStats(19);
             }
             i++;
         }
-        displayTotal(total);
+        displayTeamTotalStats(total);
         scrollView.setVisibility(View.VISIBLE);
     }
 
@@ -290,7 +290,7 @@ public class BoxScoreFragment extends Fragment implements BoxScoreView {
     }
 
 
-    public void displayTotal(StatLine statLine){
+    public void displayTeamTotalStats(StatLine statLine){
         TableRow row = new TableRow(getActivity());
         row.setLayoutParams(new ViewGroup.LayoutParams(MATCH_PARENT, WRAP_CONTENT));
 
@@ -318,7 +318,7 @@ public class BoxScoreFragment extends Fragment implements BoxScoreView {
 
     }
 
-    public void addToTotal(StatLine curr, StatLine total){
+    public void addToTeamTotalStats(StatLine curr, StatLine total){
         total.setMin(curr.getMin()+total.getMin());
         total.setPts(curr.getPts()+total.getPts());
         total.setReb(curr.getReb()+total.getReb());
@@ -335,27 +335,8 @@ public class BoxScoreFragment extends Fragment implements BoxScoreView {
         total.setPf(curr.getPf()+total.getPf());
         total.setTov(curr.getTov()+total.getTov());
         total.setPm(curr.getPm()+total.getPm());
-
-//        row.addView(addNormalItem(row, String.valueOf(statLine.getMin())));
-//        row.addView(addNormalItem(row, String.valueOf(statLine.getPts())));
-//        row.addView(addNormalItem(row, String.valueOf(statLine.getReb())));
-//        row.addView(addNormalItem(row, String.valueOf(statLine.getAst())));
-//        row.addView(addNormalItem(row, String.valueOf(statLine.getStl())));
-//        row.addView(addNormalItem(row, String.valueOf(statLine.getBlk())));
-//        row.addView(addNormalItem(row, String.valueOf(statLine.getBlka())));
-//        row.addView(addNormalItem(row, String.valueOf(statLine.getFgm())));
-//        row.addView(addNormalItem(row, String.valueOf(statLine.getFga())));
-//        row.addView(addNormalItem(row, getShootingPct(statLine.getFga(), statLine.getFgm())));
-//        row.addView(addNormalItem(row, String.valueOf(statLine.getTpm())));
-//        row.addView(addNormalItem(row, String.valueOf(statLine.getTpa())));
-//        row.addView(addNormalItem(row, getShootingPct(statLine.getTpa(), statLine.getTpm())));
-//        row.addView(addNormalItem(row, String.valueOf(statLine.getFtm())));
-//        row.addView(addNormalItem(row, String.valueOf(statLine.getFta())));
-//        row.addView(addNormalItem(row, getShootingPct(statLine.getFta(), statLine.getFtm())));
-//        row.addView(addNormalItem(row, String.valueOf(statLine.getPf())));
-//        row.addView(addNormalItem(row, String.valueOf(statLine.getTov())));
-//        row.addView(addNormalItem(row, String.valueOf(statLine.getPm())));
     }
+    
     public void addRowToStatsTable2(Optional<StatLine> statLineOptional) {
         TableRow row = new TableRow(getActivity());
         row.setLayoutParams(new ViewGroup.LayoutParams(MATCH_PARENT, WRAP_CONTENT));

--- a/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/features/boxscore/BoxScoreFragment.java
+++ b/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/features/boxscore/BoxScoreFragment.java
@@ -169,6 +169,7 @@ public class BoxScoreFragment extends Fragment implements BoxScoreView {
                 players.add(statLine.getLn());
             }
         }
+        players.add("TOTAL");
 
         int i = 1;
         addRowToPlayersTable2("PLAYER");
@@ -180,16 +181,18 @@ public class BoxScoreFragment extends Fragment implements BoxScoreView {
             i++;
         }
 
+        StatLine total = new StatLine(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"0","0");
         i = 1;
         addRowToStatsTable2(Optional.absent());
         for (StatLine statLine : values.getVls().getPstsg()) {
             addRowToStatsTable2(Optional.of(statLine));
+            addToTotal(statLine, total);
             if (i == 5) {
                 addSeparatorRowToStats(19);
             }
             i++;
         }
-
+        displayTotal(total);
         scrollView.setVisibility(View.VISIBLE);
     }
 

--- a/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/features/boxscore/BoxScoreFragment.java
+++ b/app/src/main/java/com/gmail/jorgegilcavazos/ballislife/features/boxscore/BoxScoreFragment.java
@@ -208,6 +208,7 @@ public class BoxScoreFragment extends Fragment implements BoxScoreView {
                 players.add(statLine.getLn());
             }
         }
+        players.add("TOTAL");
 
         addRowToPlayersTable2("PLAYER");
         int i = 1;
@@ -219,16 +220,18 @@ public class BoxScoreFragment extends Fragment implements BoxScoreView {
             i++;
         }
 
+        StatLine total = new StatLine(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"0","0");
         i = 1;
         addRowToStatsTable2(Optional.absent());
         for (StatLine statLine : values.getHls().getPstsg()) {
             addRowToStatsTable2(Optional.of(statLine));
+            addToTotal(statLine, total);
             if (i == 5) {
                 addSeparatorRowToStats(19);
             }
             i++;
         }
-
+        displayTotal(total);
         scrollView.setVisibility(View.VISIBLE);
     }
 
@@ -283,13 +286,80 @@ public class BoxScoreFragment extends Fragment implements BoxScoreView {
         playersTable.addView(row, new TableLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT));
     }
 
+
+    public void displayTotal(StatLine statLine){
+        TableRow row = new TableRow(getActivity());
+        row.setLayoutParams(new ViewGroup.LayoutParams(MATCH_PARENT, WRAP_CONTENT));
+
+        row.addView(addNormalItem(row, String.valueOf(statLine.getMin())));
+        row.addView(addNormalItem(row, String.valueOf(statLine.getPts())));
+        row.addView(addNormalItem(row, String.valueOf(statLine.getReb())));
+        row.addView(addNormalItem(row, String.valueOf(statLine.getAst())));
+        row.addView(addNormalItem(row, String.valueOf(statLine.getStl())));
+        row.addView(addNormalItem(row, String.valueOf(statLine.getBlk())));
+        row.addView(addNormalItem(row, String.valueOf(statLine.getBlka())));
+        row.addView(addNormalItem(row, String.valueOf(statLine.getFgm())));
+        row.addView(addNormalItem(row, String.valueOf(statLine.getFga())));
+        row.addView(addNormalItem(row, getShootingPct(statLine.getFga(), statLine.getFgm())));
+        row.addView(addNormalItem(row, String.valueOf(statLine.getTpm())));
+        row.addView(addNormalItem(row, String.valueOf(statLine.getTpa())));
+        row.addView(addNormalItem(row, getShootingPct(statLine.getTpa(), statLine.getTpm())));
+        row.addView(addNormalItem(row, String.valueOf(statLine.getFtm())));
+        row.addView(addNormalItem(row, String.valueOf(statLine.getFta())));
+        row.addView(addNormalItem(row, getShootingPct(statLine.getFta(), statLine.getFtm())));
+        row.addView(addNormalItem(row, String.valueOf(statLine.getPf())));
+        row.addView(addNormalItem(row, String.valueOf(statLine.getTov())));
+        row.addView(addNormalItem(row, String.valueOf(statLine.getPm())));
+
+        statsTable.addView(row, new TableLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT));
+
+    }
+
+    public void addToTotal(StatLine curr, StatLine total){
+        total.setMin(curr.getMin()+total.getMin());
+        total.setPts(curr.getPts()+total.getPts());
+        total.setReb(curr.getReb()+total.getReb());
+        total.setAst(curr.getAst()+total.getAst());
+        total.setStl(curr.getStl()+total.getStl());
+        total.setBlk(curr.getBlk()+total.getBlk());
+        total.setBlka(curr.getBlka()+total.getBlka());
+        total.setFgm(curr.getFgm()+total.getFgm());
+        total.setFga(curr.getFga()+total.getFga());
+        total.setTpm(curr.getTpm()+total.getTpm());
+        total.setTpa(curr.getTpa()+total.getTpa());
+        total.setFtm(curr.getFtm()+total.getFtm());
+        total.setFta(curr.getFta()+total.getFta());
+        total.setPf(curr.getPf()+total.getPf());
+        total.setTov(curr.getTov()+total.getTov());
+        total.setPm(curr.getPm()+total.getPm());
+
+//        row.addView(addNormalItem(row, String.valueOf(statLine.getMin())));
+//        row.addView(addNormalItem(row, String.valueOf(statLine.getPts())));
+//        row.addView(addNormalItem(row, String.valueOf(statLine.getReb())));
+//        row.addView(addNormalItem(row, String.valueOf(statLine.getAst())));
+//        row.addView(addNormalItem(row, String.valueOf(statLine.getStl())));
+//        row.addView(addNormalItem(row, String.valueOf(statLine.getBlk())));
+//        row.addView(addNormalItem(row, String.valueOf(statLine.getBlka())));
+//        row.addView(addNormalItem(row, String.valueOf(statLine.getFgm())));
+//        row.addView(addNormalItem(row, String.valueOf(statLine.getFga())));
+//        row.addView(addNormalItem(row, getShootingPct(statLine.getFga(), statLine.getFgm())));
+//        row.addView(addNormalItem(row, String.valueOf(statLine.getTpm())));
+//        row.addView(addNormalItem(row, String.valueOf(statLine.getTpa())));
+//        row.addView(addNormalItem(row, getShootingPct(statLine.getTpa(), statLine.getTpm())));
+//        row.addView(addNormalItem(row, String.valueOf(statLine.getFtm())));
+//        row.addView(addNormalItem(row, String.valueOf(statLine.getFta())));
+//        row.addView(addNormalItem(row, getShootingPct(statLine.getFta(), statLine.getFtm())));
+//        row.addView(addNormalItem(row, String.valueOf(statLine.getPf())));
+//        row.addView(addNormalItem(row, String.valueOf(statLine.getTov())));
+//        row.addView(addNormalItem(row, String.valueOf(statLine.getPm())));
+    }
     public void addRowToStatsTable2(Optional<StatLine> statLineOptional) {
         TableRow row = new TableRow(getActivity());
         row.setLayoutParams(new ViewGroup.LayoutParams(MATCH_PARENT, WRAP_CONTENT));
 
         if (statLineOptional.isPresent()) {
             StatLine statLine = statLineOptional.get();
-
+//
             row.addView(addNormalItem(row, String.valueOf(statLine.getMin())));
             row.addView(addNormalItem(row, String.valueOf(statLine.getPts())));
             row.addView(addNormalItem(row, String.valueOf(statLine.getReb())));


### PR DESCRIPTION
Added total values for each team in the box score. 

The "total minutes" are slightly off because of rounding.

Any feedback is welcomed and appreciated! Thanks!

<img width="295" alt="screen shot 2017-10-30 at 1 53 08 pm" src="https://user-images.githubusercontent.com/11788633/32195173-c54b0510-bd79-11e7-928a-c158e535a9b4.png">
<img width="295" alt="screen shot 2017-10-30 at 1 52 24 pm" src="https://user-images.githubusercontent.com/11788633/32195176-c81b56f0-bd79-11e7-9a8b-2ed6461abdb8.png">
